### PR TITLE
Add ChunkedReliableQueue for chunking queues

### DIFF
--- a/src/ChunkedReliableQueue.php
+++ b/src/ChunkedReliableQueue.php
@@ -1,0 +1,104 @@
+<?php
+namespace Altmetric;
+
+use Redis;
+use Psr\Log\LoggerInterface;
+
+class ChunkedReliableQueue implements \Iterator
+{
+    public $name;
+    public $queue;
+    public $size;
+    public $workingQueue;
+    private $redis;
+    private $logger;
+    private $value;
+
+    public function __construct($name, $size, $queue, Redis $redis, LoggerInterface $logger)
+    {
+        $this->name = $name;
+        $this->size = $size;
+        $this->queue = $queue;
+        $this->redis = $redis;
+        $this->logger = $logger;
+        $this->workingQueue = "{$queue}.working_on.{$name}";
+    }
+
+    public function rewind()
+    {
+        while ($reply = $this->redis->rPopLPush($this->workingQueue, $this->queue)) {
+            $this->logger->debug("Pushed unfinished work from {$this->workingQueue} to {$this->queue}: {$reply}");
+        }
+
+        $this->logger->debug("Popping work from {$this->queue}");
+        $this->fetchNewWork();
+    }
+
+    public function valid()
+    {
+        return true;
+    }
+
+    public function current()
+    {
+        return $this->value;
+    }
+
+    public function key()
+    {
+        return $this->queue;
+    }
+
+    public function next()
+    {
+        $this->finishCurrentWork();
+        $this->fetchNewWork();
+    }
+
+    private function finishCurrentWork()
+    {
+        $pipeline = $this->redis->multi();
+
+        foreach ($this->current() as $item) {
+            $pipeline->lRem($this->workingQueue, $item, 0);
+        }
+
+        $pipeline->exec();
+    }
+
+    private function fetchNewWork()
+    {
+        while (true) {
+            $reply = $this->redis->bRPopLPush($this->queue, $this->workingQueue, 30);
+            if ($reply) {
+                $replies = $this->eagerlyFetchWork();
+                array_unshift($replies, $reply);
+
+                $this->value = $replies;
+                break;
+            }
+
+            $this->logger->debug("Timeout waiting for new work from {$this->queue}, trying again");
+        }
+    }
+
+    private function eagerlyFetchWork()
+    {
+        $replies = [];
+        $pipeline = $this->redis->multi();
+
+        for ($i = 1; $i < $this->size; $i += 1) {
+            $pipeline->rPopLPush($this->queue, $this->workingQueue);
+        }
+
+        foreach ($pipeline->exec() as $reply) {
+            if ($reply === false) {
+                break;
+            }
+
+            $replies[] = $reply;
+        }
+
+        return $replies;
+    }
+}

--- a/tests/ChunkedReliableQueueTest.php
+++ b/tests/ChunkedReliableQueueTest.php
@@ -1,0 +1,93 @@
+<?php
+namespace Altmetric;
+
+use Altmetric\ChunkedReliableQueue;
+use PHPUnit_Framework_TestCase as TestCase;
+use Psr\Log\NullLogger;
+use Redis;
+
+class ChunkedReliableQueueTest extends TestCase
+{
+    public function testRewindSetsCurrentToAFullChunk()
+    {
+        $queue = $this->buildChunkedQueue('alice', 2, 'reliable-queue-test');
+        $this->redis->lPush('reliable-queue-test', 1, 2, 3);
+
+        $queue->rewind();
+
+        $this->assertSame(['1', '2'], $queue->current());
+    }
+
+    public function testRewindSetsCurrentToAPartialChunk()
+    {
+        $queue = $this->buildChunkedQueue('alice', 2, 'reliable-queue-test');
+        $this->redis->lPush('reliable-queue-test', 1);
+
+        $queue->rewind();
+
+        $this->assertSame(['1'], $queue->current());
+    }
+
+    public function testNextSetsCurrentToPoppedWork()
+    {
+        $queue = $this->buildChunkedQueue('alice', 2, 'reliable-queue-test');
+        $this->redis->lPush('reliable-queue-test', 1, 2, 3, 4);
+
+        $queue->rewind();
+        $queue->next();
+
+        $this->assertSame(['3', '4'], $queue->current());
+    }
+
+    public function testRewindPullsAChunkOfUnfinishedWork()
+    {
+        $queue = $this->buildChunkedQueue('alice', 2, 'reliable-queue-test');
+        $this->redis->lPush('reliable-queue-test.working_on.alice', 1, 2);
+
+        $queue->rewind();
+
+        $this->assertSame(['1', '2'], $queue->current());
+    }
+
+    public function testNextFinishesWorkAndStoreCurrentInWorkingOn()
+    {
+        $queue = $this->buildChunkedQueue('alice', 2, 'reliable-queue-test');
+        $this->redis->lPush('reliable-queue-test', 1, 2, 3, 4);
+
+        $queue->rewind();
+        $queue->next();
+
+        $this->assertSame(['4', '3'], $this->redis->lRange('reliable-queue-test.working_on.alice', 0, -1));
+    }
+
+    public function testKeyIsQueueName()
+    {
+        $queue = $this->buildChunkedQueue('alice', 2, 'reliable-queue-test');
+
+        $this->assertEquals('reliable-queue-test', $queue->key());
+    }
+
+    public function testValidIsAlwaysTrue()
+    {
+        $queue = $this->buildChunkedQueue('alice', 2, 'reliable-queue-test');
+
+        $this->assertTrue($queue->valid());
+    }
+
+    public function setUp()
+    {
+        $this->logger = new NullLogger();
+        $this->redis = new Redis();
+        $this->redis->connect('localhost');
+    }
+
+    public function tearDown()
+    {
+        $this->redis->del('reliable-queue-test', 'reliable-queue-test.working_on.alice');
+    }
+
+    private function buildChunkedQueue($name, $size, $queue)
+    {
+        return new ChunkedReliableQueue($name, $size, $queue, $this->redis, $this->logger);
+    }
+}


### PR DESCRIPTION
As we often work on high-throughput queues where we want to batch up work, introduce a new ChunkedReliableQueue which will yield a chunk of work on each iteration rather than a single value.

This works by eagerly fetching extra work on every iteration up to some specified limit. If insufficient work exists, the chunk may be smaller than the specified size.
