### PR TITLE
Add priority reliable queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ $ composer require altmetric/reliable-queue
 <?php
 use Altmetric\ReliableQueue;
 use Altmetric\ChunkedReliableQueue;
+use Altmetric\PriorityReliableQueue;
 
 $queue = new ReliableQueue('unique-worker-name', 'to-do-queue', $redis, $logger);
 $queue[] = 'some-work';
@@ -30,6 +31,12 @@ $queue = new ChunkedReliableQueue('unique-worker-name', 100, 'to-do-queue', $red
 
 foreach ($queue as $chunk) {
     // $chunk will be an array of up to 100 pieces of work
+}
+
+$queue = new PriorityReliableQueue('unique-worker-name', array('critical-queue', 'default-queue', 'low-priority-queue'), $redis, $logger);
+
+foreach ($queue as $name => $work) {
+    // $work will be popped from the queue $name in the priority order given
 }
 ```
 
@@ -110,6 +117,40 @@ perspective.
 If the queue contains sufficient items, the chunk of work will contain at most
 `$size` elements but if there is not enough work, it may return less (but
 always at least 1 value).
+
+### `public PriorityReliableQueue:__construct(string $name, array $queues, Redis $redis, LoggerInterface $logger)`
+
+```php
+$queue = new \Altmetric\PriorityReliableQueue('unique-worker-name', array('critical-queue', 'default-queue', 'low-priority-queue'), $redis, $logger);
+```
+
+Instantiate a new priority-ordered, reliable queue object with the following arguments:
+
+* `$name`: a unique `string` name for this worker so that we can pick up any unfinished work in the event of a crash;
+* `$queues`: an `array` of `string` keys of lists in Redis to use as queues given in priority order;
+* `$redis`: a [`Redis`](https://github.com/phpredis/phpredis) client object for communication with Redis;
+* `$logger`: a
+  [`Psr\Log\LoggerInterface`](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md)-compliant
+  logger.
+
+The returned object implements the
+[`Iterator`](http://php.net/manual/en/class.iterator.php) (and therefore
+[`Traversable`](http://php.net/manual/en/class.traversable.php)) interface in
+PHP.
+
+This means that it can be iterated over with `foreach`, yielding the queue name
+and a value on every iteration. Queues will be checked for work in the order
+given in `$queues` meaning that any work in the first queue will take priority
+over work in the second, any work in the second queue will take priority over
+work in the third and so on. Internally, the library will repeatedly poll for
+new work but this is invisible from a client's perspective.
+
+```php
+foreach ($queue as $key => $work) {
+    // $key will be the queue key name in Redis
+    // $work will be the value popped from the queue
+}
+```
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -139,11 +139,11 @@ The returned object implements the
 PHP.
 
 This means that it can be iterated over with `foreach`, yielding the queue name
-and a value on every iteration. Queues will be checked for work in the order
-given in `$queues` meaning that any work in the first queue will take priority
-over work in the second, any work in the second queue will take priority over
-work in the third and so on. Internally, the library will repeatedly poll for
-new work but this is invisible from a client's perspective.
+and a value on every iteration. Queues will be checked randomly for work based
+on their priority order given in `$queues` meaning that the first queue will be
+checked more often than the second, the second more than the third and so on.
+Internally, the library will repeatedly poll for new work but this is invisible
+from a client's perspective.
 
 ```php
 foreach ($queue as $key => $work) {
@@ -155,6 +155,11 @@ foreach ($queue as $key => $work) {
 ## References
 
 * [Pattern: Reliable queue](http://redis.io/commands/rpoplpush#pattern-reliable-queue)
+
+## Acknowledgements
+
+* Thanks to [James Adam](https://github.com/lazyatom) for suggesting a way to
+  test the randomness of the priority queue.
 
 ## License
 

--- a/src/PriorityReliableQueue.php
+++ b/src/PriorityReliableQueue.php
@@ -1,0 +1,92 @@
+<?php
+namespace Altmetric;
+
+use Redis;
+use Psr\Log\LoggerInterface;
+
+class PriorityReliableQueue implements \Iterator
+{
+    public $name;
+    public $queues;
+    private $redis;
+    private $logger;
+    private $value;
+    private $queue;
+    private $workingQueue;
+
+    public function __construct($name, array $queues, Redis $redis, LoggerInterface $logger)
+    {
+        $this->name = $name;
+        $this->redis = $redis;
+        $this->logger = $logger;
+
+        foreach ($queues as $queue) {
+            $this->queues[$queue] = "{$queue}.working_on.{$name}";
+        }
+    }
+
+    public function rewind()
+    {
+        foreach ($this->queues as $queue => $workingQueue) {
+            while ($reply = $this->redis->rPopLPush($workingQueue, $queue)) {
+                $this->logger->debug("Pushed unfinished work from {$workingQueue} to {$queue}: {$reply}");
+            }
+        }
+
+        $this->logger->debug('Popping work from queues: ' . implode(', ', $this->queues));
+        $this->fetchNewWork();
+    }
+
+    public function valid()
+    {
+        return true;
+    }
+
+    public function current()
+    {
+        return $this->value;
+    }
+
+    public function key()
+    {
+        return $this->queue;
+    }
+
+    public function next()
+    {
+        $this->finishCurrentWork();
+        $this->fetchNewWork();
+    }
+
+    private function finishCurrentWork()
+    {
+        $workingQueue = $this->currentWorkingQueue();
+        $numberRemoved = $this->redis->lRem($workingQueue, $this->current(), 0);
+        if ($numberRemoved) {
+            $this->logger->debug("Removed {$numberRemoved} finished item(s) from {$workingQueue}");
+        }
+    }
+
+    private function fetchNewWork()
+    {
+        while (true) {
+            foreach ($this->queues as $queue => $workingQueue) {
+                $reply = $this->redis->rPopLPush($queue, $workingQueue);
+                if ($reply) {
+                    $this->value = $reply;
+                    $this->queue = $queue;
+                    $this->workingQueue = $workingQueue;
+                    break 2;
+                }
+            }
+
+            $this->logger->debug('No work in queues ' . implode(', ', $this->queues) . ', trying again');
+        }
+    }
+
+    private function currentWorkingQueue()
+    {
+        return $this->workingQueue;
+    }
+}
+

--- a/tests/PriorityReliableQueueTest.php
+++ b/tests/PriorityReliableQueueTest.php
@@ -1,0 +1,194 @@
+<?php
+namespace Altmetric;
+
+use Altmetric\ReliableQueue;
+use PHPUnit_Framework_TestCase as TestCase;
+use Psr\Log\NullLogger;
+use Redis;
+
+class PriorityReliableQueueTest extends TestCase
+{
+    public function testWorkerIsAlwaysValid()
+    {
+        $queue = $this->buildPriorityReliableQueue('alice', array('reliable-queue-test', 'reliable-queue-test-2'));
+
+        $this->assertTrue($queue->valid());
+    }
+
+   public function testRewindPushesAnyUnfinishedWork()
+    {
+        $queue = $this->buildPriorityReliableQueue('alice', array('reliable-queue-test'));
+        $this->redis->lPush('reliable-queue-test.working_on.alice', 1, 2, 3, 4, 5);
+
+        $queue->rewind();
+
+        $this->assertSame(array('5', '4', '3', '2'), $this->redis->lRange('reliable-queue-test', 0, 5));
+    }
+
+   public function testRewindPushesAnyUnfinishedWorkForAllQueues()
+    {
+        $queue = $this->buildPriorityReliableQueue('alice', array('reliable-queue-test', 'reliable-queue-test-2'));
+        $this->redis->lPush('reliable-queue-test-2.working_on.alice', 1, 2, 3, 4, 5);
+
+        $queue->rewind();
+
+        $this->assertSame(array('5', '4', '3', '2'), $this->redis->lRange('reliable-queue-test-2', 0, 5));
+    }
+
+    public function testRewindPullsTheFirstUnfinishedPieceOfWork()
+    {
+        $queue = $this->buildPriorityReliableQueue('alice', array('reliable-queue-test', 'reliable-queue-test-2'));
+        $this->redis->lPush('reliable-queue-test.working_on.alice', 1);
+
+        $queue->rewind();
+
+        $this->assertEquals('1', $queue->current());
+    }
+
+    public function testRewindPullsTheFirstUnfinishedPieceOfWorkFromAllQueues()
+    {
+        $queue = $this->buildPriorityReliableQueue('alice', array('reliable-queue-test', 'reliable-queue-test-2'));
+        $this->redis->lPush('reliable-queue-test-2.working_on.alice', 1);
+
+        $queue->rewind();
+
+        $this->assertEquals('1', $queue->current());
+    }
+
+    public function testRewindSetsTheKeyToTheQueueName()
+    {
+        $queue = $this->buildPriorityReliableQueue('alice', array('reliable-queue-test', 'reliable-queue-test-2'));
+        $this->redis->lPush('reliable-queue-test.working_on.alice', 1);
+
+        $queue->rewind();
+
+        $this->assertEquals('reliable-queue-test', $queue->key());
+    }
+
+    public function testRewindSetsTheKeyToTheQueueNameForOtherQueues()
+    {
+        $queue = $this->buildPriorityReliableQueue('alice', array('reliable-queue-test', 'reliable-queue-test-2'));
+        $this->redis->lPush('reliable-queue-test-2.working_on.alice', 1);
+
+        $queue->rewind();
+
+        $this->assertEquals('reliable-queue-test-2', $queue->key());
+    }
+
+    public function testRewindPullsTheFirstPieceOfWorkIfNoneUnfinished()
+    {
+        $queue = $this->buildPriorityReliableQueue('alice', array('reliable-queue-test', 'reliable-queue-test-2'));
+        $this->redis->lPush('reliable-queue-test', 1, 2);
+
+        $queue->rewind();
+
+        $this->assertEquals('1', $queue->current());
+    }
+
+    public function testRewindPullsTheFirstPieceOfWorkFromAnyQueueIfNoneUnfinished()
+    {
+        $queue = $this->buildPriorityReliableQueue('alice', array('reliable-queue-test', 'reliable-queue-test-2'));
+        $this->redis->lPush('reliable-queue-test-2', 1, 2);
+
+        $queue->rewind();
+
+        $this->assertEquals('1', $queue->current());
+    }
+
+    public function testRewindPullsTheFirstPieceOfWorkFromFirstQueueBeforeSecond()
+    {
+        $queue = $this->buildPriorityReliableQueue('alice', array('reliable-queue-test', 'reliable-queue-test-2'));
+        $this->redis->lPush('reliable-queue-test', 1, 2);
+        $this->redis->lPush('reliable-queue-test-2', 3, 4);
+
+        $queue->rewind();
+
+        $this->assertEquals('1', $queue->current());
+    }
+
+    public function testNextSetsCurrentToPoppedWork()
+    {
+        $queue = $this->buildPriorityReliableQueue('alice', array('reliable-queue-test', 'reliable-queue-test-2'));
+        $this->redis->lPush('reliable-queue-test', 1, 2);
+
+        $queue->rewind();
+        $queue->next();
+
+        $this->assertEquals('2', $queue->current());
+    }
+
+    public function testNextSetsCurrentToPoppedWorkFromAnyQueue()
+    {
+        $queue = $this->buildPriorityReliableQueue('alice', array('reliable-queue-test', 'reliable-queue-test-2'));
+        $this->redis->lPush('reliable-queue-test-2', 1, 2);
+
+        $queue->rewind();
+        $queue->next();
+
+        $this->assertEquals('2', $queue->current());
+    }
+
+    public function testNextSetsCurrentToPoppedWorkFromFirstQueueBeforeSecond()
+    {
+        $queue = $this->buildPriorityReliableQueue('alice', array('reliable-queue-test', 'reliable-queue-test-2'));
+        $this->redis->lPush('reliable-queue-test', 1, 2);
+        $this->redis->lPush('reliable-queue-test-2', 3, 4);
+
+        $queue->rewind();
+        $queue->next();
+
+        $this->assertEquals('2', $queue->current());
+    }
+
+    public function testNextOnlyPullsFromSecondQueueOnceFirstIsEmpty()
+    {
+        $queue = $this->buildPriorityReliableQueue('alice', array('reliable-queue-test', 'reliable-queue-test-2'));
+        $this->redis->lPush('reliable-queue-test', 1, 2);
+        $this->redis->lPush('reliable-queue-test-2', 3, 4);
+
+        $queue->rewind();
+        $queue->next();
+        $queue->next();
+
+        $this->assertEquals('3', $queue->current());
+    }
+
+    public function testNextFinishesWorkAndStoresCurrentInWorkingOn()
+    {
+        $queue = $this->buildPriorityReliableQueue('alice', array('reliable-queue-test', 'reliable-queue-test-2'));
+        $this->redis->lPush('reliable-queue-test', 1, 2);
+
+        $queue->rewind();
+        $queue->next();
+
+        $this->assertSame(array('2'), $this->redis->lRange('reliable-queue-test.working_on.alice', 0, -1));
+    }
+
+    public function testNextFinishesWorkAndStoresCurrentInWorkingOnForAnyQueue()
+    {
+        $queue = $this->buildPriorityReliableQueue('alice', array('reliable-queue-test', 'reliable-queue-test-2'));
+        $this->redis->lPush('reliable-queue-test-2', 1, 2);
+
+        $queue->rewind();
+        $queue->next();
+
+        $this->assertSame(array('2'), $this->redis->lRange('reliable-queue-test-2.working_on.alice', 0, -1));
+    }
+
+    public function setUp()
+    {
+        $this->logger = new NullLogger();
+        $this->redis = new Redis();
+        $this->redis->connect('localhost');
+    }
+
+    public function tearDown()
+    {
+        $this->redis->del('reliable-queue-test', 'reliable-queue-test-2', 'reliable-queue-test.working_on.alice', 'reliable-queue-test-2.working_on.alice');
+    }
+
+    private function buildPriorityReliableQueue($name, array $queues)
+    {
+        return new PriorityReliableQueue($name, $queues, $this->redis, $this->logger);
+    }
+}


### PR DESCRIPTION
So that a single worker can process work from multiple queues of different priority (e.g. a "critical" queue, a default queue and a "backlog" queue), add a new Priority Reliable Queue class which will check a given array of Redis keys for work in a specific order.

This will ensure that the highest priority queue is empty before checking the next queue for work and so on until the last queue.