### PR TITLE
Setting  Redis::OPT_READ_TIMEOUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ use Altmetric\ReliableQueue;
 use Altmetric\ChunkedReliableQueue;
 use Altmetric\PriorityReliableQueue;
 
-//Read timeout should be higher then BRPOPLPUSH timeout or -1 for infinity
-$redis->setOption(Redis::OPT_READ_TIMEOUT, -1);
+//Read timeout should be higher then BRPOPLPUSH timeout or -1 for infinity (PHP >=5.6)
+//$redis->setOption(Redis::OPT_READ_TIMEOUT, -1);
 
 $queue = new ReliableQueue('unique-worker-name', 'to-do-queue', $redis, $logger);
 $queue[] = 'some-work';

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ use Altmetric\ReliableQueue;
 use Altmetric\ChunkedReliableQueue;
 use Altmetric\PriorityReliableQueue;
 
+//Read timeout should be higher then BRPOPLPUSH timeout or -1 for infinity
+$redis->setOption(Redis::OPT_READ_TIMEOUT, -1);
+
 $queue = new ReliableQueue('unique-worker-name', 'to-do-queue', $redis, $logger);
 $queue[] = 'some-work';
 $queue[] = 'some-more-work';


### PR DESCRIPTION
Redis throws an Exception if Redis::OPT_READ_TIMEOUT is less then BRPOPLPUSH timeout